### PR TITLE
Don't hardcode serialized JSON in server tests

### DIFF
--- a/_fixtures/fncall.go
+++ b/_fixtures/fncall.go
@@ -121,7 +121,7 @@ func noreturncall(n int) {
 	return
 }
 
-type Base struct{
+type Base struct {
 	y int
 }
 
@@ -132,6 +132,18 @@ type Derived struct {
 
 func (b *Base) Method() int {
 	return b.y
+}
+
+type X int
+
+func (_ X) CallMe() {
+	println("foo")
+}
+
+type X2 int
+
+func (_ X2) CallMe(i int) int {
+	return i * i
 }
 
 func main() {
@@ -148,6 +160,8 @@ func main() {
 	var vable_a VRcvrable = a
 	var vable_pa VRcvrable = pa
 	var pable_pa PRcvrable = pa
+	var x X = 2
+	var x2 X2 = 2
 
 	fn2clos := makeclos(pa)
 	fn2glob := call1
@@ -163,5 +177,6 @@ func main() {
 	strings.LastIndexByte(stringslice[1], 'w')
 	d.Method()
 	d.Base.Method()
-	fmt.Println(one, two, zero, callpanic, callstacktrace, stringsJoin, intslice, stringslice, comma, a.VRcvr, a.PRcvr, pa, vable_a, vable_pa, pable_pa, fn2clos, fn2glob, fn2valmeth, fn2ptrmeth, fn2nil, ga, escapeArg, a2, square, intcallpanic, onetwothree, curriedAdd, getAStruct, getAStructPtr, getVRcvrableFromAStruct, getPRcvrableFromAStructPtr, getVRcvrableFromAStructPtr, pa2, noreturncall, str, d)
+	x.CallMe()
+	fmt.Println(one, two, zero, callpanic, callstacktrace, stringsJoin, intslice, stringslice, comma, a.VRcvr, a.PRcvr, pa, vable_a, vable_pa, pable_pa, fn2clos, fn2glob, fn2valmeth, fn2ptrmeth, fn2nil, ga, escapeArg, a2, square, intcallpanic, onetwothree, curriedAdd, getAStruct, getAStructPtr, getVRcvrableFromAStruct, getPRcvrableFromAStructPtr, getVRcvrableFromAStructPtr, pa2, noreturncall, str, d, x, x2.CallMe(5))
 }

--- a/pkg/proc/disasm.go
+++ b/pkg/proc/disasm.go
@@ -1,5 +1,7 @@
 package proc
 
+import "fmt"
+
 // AsmInstruction represents one assembly instruction.
 type AsmInstruction struct {
 	Loc        Location
@@ -101,6 +103,9 @@ func checkPrologue(s []AsmInstruction, prologuePattern opcodeSeq) bool {
 // will evaluate the argument of the CALL instruction using the thread's registers.
 // Be aware that the Bytes field of each returned instruction is a slice of a larger array of size startAddr - endAddr.
 func Disassemble(mem MemoryReadWriter, regs Registers, breakpoints *BreakpointMap, bi *BinaryInfo, startAddr, endAddr uint64) ([]AsmInstruction, error) {
+	if startAddr > endAddr {
+		return nil, fmt.Errorf("start address(%x) should be less than end address(%x)", startAddr, endAddr)
+	}
 	return disassemble(mem, regs, breakpoints, bi, startAddr, endAddr, false)
 }
 

--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -437,7 +437,12 @@ func funcCallEvalFuncExpr(scope *EvalScope, fncall *functionCallState, allowCall
 
 	argnum := len(fncall.expr.Args)
 
-	if len(fnvar.Children) > 0 {
+	// If the function variable has a child then that child is the method
+	// receiver. However, if the method receiver is not being used (e.g.
+	// func (_ X) Foo()) then it will not actually be listed as a formal
+	// argument. Ensure that we are really off by 1 to add the receiver to
+	// the function call.
+	if len(fnvar.Children) > 0 && argnum == (len(fncall.formalArgs)-1) {
 		argnum++
 		fncall.receiver = &fnvar.Children[0]
 		fncall.receiver.Name = exprToString(fncall.expr.Fun)

--- a/service/dap/daptest/client.go
+++ b/service/dap/daptest/client.go
@@ -3,11 +3,11 @@ package daptest
 import (
 	"bufio"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"net"
 	"path/filepath"
+	"testing"
 
 	"github.com/google/go-dap"
 )
@@ -49,6 +49,94 @@ func (c *Client) send(request dap.Message) {
 	dap.WriteProtocolMessage(c.conn, request)
 }
 
+func (c *Client) ExpectDisconnectResponse(t *testing.T) *dap.DisconnectResponse {
+	response, err := dap.ReadProtocolMessage(c.reader)
+	if err != nil {
+		t.Error(err)
+	}
+	return response.(*dap.DisconnectResponse)
+}
+
+func (c *Client) ExpectErrorResponse(t *testing.T) *dap.ErrorResponse {
+	response, err := dap.ReadProtocolMessage(c.reader)
+	if err != nil {
+		t.Error(err)
+	}
+	return response.(*dap.ErrorResponse)
+}
+
+func (c *Client) ExpectContinueResponse(t *testing.T) *dap.ContinueResponse {
+	response, err := dap.ReadProtocolMessage(c.reader)
+	if err != nil {
+		t.Error(err)
+	}
+	return response.(*dap.ContinueResponse)
+}
+
+func (c *Client) ExpectTerminatedEvent(t *testing.T) *dap.TerminatedEvent {
+	response, err := dap.ReadProtocolMessage(c.reader)
+	if err != nil {
+		t.Error(err)
+	}
+	return response.(*dap.TerminatedEvent)
+}
+
+func (c *Client) ExpectInitializeResponse(t *testing.T) *dap.InitializeResponse {
+	response, err := dap.ReadProtocolMessage(c.reader)
+	if err != nil {
+		t.Error(err)
+	}
+	return response.(*dap.InitializeResponse)
+}
+
+func (c *Client) ExpectInitializedEvent(t *testing.T) *dap.InitializedEvent {
+	response, err := dap.ReadProtocolMessage(c.reader)
+	if err != nil {
+		t.Error(err)
+	}
+	return response.(*dap.InitializedEvent)
+}
+
+func (c *Client) ExpectLaunchResponse(t *testing.T) *dap.LaunchResponse {
+	response, err := dap.ReadProtocolMessage(c.reader)
+	if err != nil {
+		t.Error(err)
+	}
+	return response.(*dap.LaunchResponse)
+}
+
+func (c *Client) ExpectSetExceptionBreakpointsResponse(t *testing.T) *dap.SetExceptionBreakpointsResponse {
+	response, err := dap.ReadProtocolMessage(c.reader)
+	if err != nil {
+		t.Error(err)
+	}
+	return response.(*dap.SetExceptionBreakpointsResponse)
+}
+
+func (c *Client) ExpectSetBreakpointsResponse(t *testing.T) *dap.SetBreakpointsResponse {
+	response, err := dap.ReadProtocolMessage(c.reader)
+	if err != nil {
+		t.Error(err)
+	}
+	return response.(*dap.SetBreakpointsResponse)
+}
+
+func (c *Client) ExpectStoppedEvent(t *testing.T) *dap.StoppedEvent {
+	response, err := dap.ReadProtocolMessage(c.reader)
+	if err != nil {
+		t.Error(err)
+	}
+	return response.(*dap.StoppedEvent)
+}
+
+func (c *Client) ExpectConfigurationDoneResponse(t *testing.T) *dap.ConfigurationDoneResponse {
+	response, err := dap.ReadProtocolMessage(c.reader)
+	if err != nil {
+		t.Error(err)
+	}
+	return response.(*dap.ConfigurationDoneResponse)
+}
+
 // ReadBaseMessage reads and returns a json-encoded DAP message.
 func (c *Client) ReadBaseMessage() ([]byte, error) {
 	message, err := dap.ReadBaseMessage(c.reader)
@@ -58,21 +146,6 @@ func (c *Client) ReadBaseMessage() ([]byte, error) {
 	}
 	fmt.Println("[client <- server]", string(message))
 	return message, nil
-}
-
-// ReadErrorResponse reads, decodes and validates the result
-// to be an error response. Returns the response or an error.
-func (c *Client) ReadErrorResponse() (dap.Message, error) {
-	response, err := dap.ReadProtocolMessage(c.reader)
-	if err != nil {
-		return nil, err
-	}
-	switch response.(type) {
-	case *dap.ErrorResponse:
-		return response, nil
-	default:
-		return nil, errors.New(fmt.Sprintf("not an ErrorResponse: %#v", response))
-	}
 }
 
 // InitializeRequest sends an 'initialize' request.

--- a/service/dap/daptest/client.go
+++ b/service/dap/daptest/client.go
@@ -50,102 +50,91 @@ func (c *Client) send(request dap.Message) {
 }
 
 func (c *Client) ExpectDisconnectResponse(t *testing.T) *dap.DisconnectResponse {
-	response, err := dap.ReadProtocolMessage(c.reader)
+	m, err := dap.ReadProtocolMessage(c.reader)
 	if err != nil {
 		t.Error(err)
 	}
-	return response.(*dap.DisconnectResponse)
+	return m.(*dap.DisconnectResponse)
 }
 
 func (c *Client) ExpectErrorResponse(t *testing.T) *dap.ErrorResponse {
-	response, err := dap.ReadProtocolMessage(c.reader)
+	m, err := dap.ReadProtocolMessage(c.reader)
 	if err != nil {
 		t.Error(err)
 	}
-	return response.(*dap.ErrorResponse)
+	return m.(*dap.ErrorResponse)
 }
 
 func (c *Client) ExpectContinueResponse(t *testing.T) *dap.ContinueResponse {
-	response, err := dap.ReadProtocolMessage(c.reader)
+	m, err := dap.ReadProtocolMessage(c.reader)
 	if err != nil {
 		t.Error(err)
 	}
-	return response.(*dap.ContinueResponse)
+	return m.(*dap.ContinueResponse)
 }
 
 func (c *Client) ExpectTerminatedEvent(t *testing.T) *dap.TerminatedEvent {
-	response, err := dap.ReadProtocolMessage(c.reader)
+	m, err := dap.ReadProtocolMessage(c.reader)
 	if err != nil {
 		t.Error(err)
 	}
-	return response.(*dap.TerminatedEvent)
+	return m.(*dap.TerminatedEvent)
 }
 
 func (c *Client) ExpectInitializeResponse(t *testing.T) *dap.InitializeResponse {
-	response, err := dap.ReadProtocolMessage(c.reader)
+	m, err := dap.ReadProtocolMessage(c.reader)
 	if err != nil {
 		t.Error(err)
 	}
-	return response.(*dap.InitializeResponse)
+	return m.(*dap.InitializeResponse)
 }
 
 func (c *Client) ExpectInitializedEvent(t *testing.T) *dap.InitializedEvent {
-	response, err := dap.ReadProtocolMessage(c.reader)
+	m, err := dap.ReadProtocolMessage(c.reader)
 	if err != nil {
 		t.Error(err)
 	}
-	return response.(*dap.InitializedEvent)
+	return m.(*dap.InitializedEvent)
 }
 
 func (c *Client) ExpectLaunchResponse(t *testing.T) *dap.LaunchResponse {
-	response, err := dap.ReadProtocolMessage(c.reader)
+	m, err := dap.ReadProtocolMessage(c.reader)
 	if err != nil {
 		t.Error(err)
 	}
-	return response.(*dap.LaunchResponse)
+	return m.(*dap.LaunchResponse)
 }
 
 func (c *Client) ExpectSetExceptionBreakpointsResponse(t *testing.T) *dap.SetExceptionBreakpointsResponse {
-	response, err := dap.ReadProtocolMessage(c.reader)
+	m, err := dap.ReadProtocolMessage(c.reader)
 	if err != nil {
 		t.Error(err)
 	}
-	return response.(*dap.SetExceptionBreakpointsResponse)
+	return m.(*dap.SetExceptionBreakpointsResponse)
 }
 
 func (c *Client) ExpectSetBreakpointsResponse(t *testing.T) *dap.SetBreakpointsResponse {
-	response, err := dap.ReadProtocolMessage(c.reader)
+	m, err := dap.ReadProtocolMessage(c.reader)
 	if err != nil {
 		t.Error(err)
 	}
-	return response.(*dap.SetBreakpointsResponse)
+	return m.(*dap.SetBreakpointsResponse)
 }
 
 func (c *Client) ExpectStoppedEvent(t *testing.T) *dap.StoppedEvent {
-	response, err := dap.ReadProtocolMessage(c.reader)
+	m, err := dap.ReadProtocolMessage(c.reader)
 	if err != nil {
 		t.Error(err)
 	}
-	return response.(*dap.StoppedEvent)
+	return m.(*dap.StoppedEvent)
 }
 
 func (c *Client) ExpectConfigurationDoneResponse(t *testing.T) *dap.ConfigurationDoneResponse {
-	response, err := dap.ReadProtocolMessage(c.reader)
+	m, err := dap.ReadProtocolMessage(c.reader)
 	if err != nil {
 		t.Error(err)
 	}
-	return response.(*dap.ConfigurationDoneResponse)
-}
-
-// ReadBaseMessage reads and returns a json-encoded DAP message.
-func (c *Client) ReadBaseMessage() ([]byte, error) {
-	message, err := dap.ReadBaseMessage(c.reader)
-	if err != nil {
-		fmt.Println("DAP client error:", err)
-		return nil, err
-	}
-	fmt.Println("[client <- server]", string(message))
-	return message, nil
+	return m.(*dap.ConfigurationDoneResponse)
 }
 
 // InitializeRequest sends an 'initialize' request.

--- a/service/dap/daptest/client.go
+++ b/service/dap/daptest/client.go
@@ -86,7 +86,11 @@ func (c *Client) ExpectInitializeResponse(t *testing.T) *dap.InitializeResponse 
 	if err != nil {
 		t.Error(err)
 	}
-	return m.(*dap.InitializeResponse)
+	initResp := m.(*dap.InitializeResponse)
+	if !initResp.Body.SupportsConfigurationDoneRequest {
+		t.Errorf("got %#v, want SupportsConfigurationDoneRequest=true", initResp)
+	}
+	return initResp
 }
 
 func (c *Client) ExpectInitializedEvent(t *testing.T) *dap.InitializedEvent {

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -75,27 +75,28 @@ func TestStopOnEntry(t *testing.T) {
 		client.ConfigurationDoneRequest()
 		stopEvent := client.ExpectStoppedEvent(t)
 		if stopEvent.Body.Reason != "breakpoint" ||
+			stopEvent.Seq != 0 ||
 			stopEvent.Body.ThreadId != 1 ||
 			!stopEvent.Body.AllThreadsStopped {
-			t.Errorf("got %#v, want Body Reason=\"breakpoint\", ThreadId=1, AllThreadsStopped=true", stopEvent)
+			t.Errorf("got %#v, want Body Reason=\"breakpoint\", Seq=0, ThreadId=1, AllThreadsStopped=true", stopEvent)
 		}
 
 		cdResp := client.ExpectConfigurationDoneResponse(t)
-		if cdResp.RequestSeq != 3 {
-			t.Errorf("got %#v, want RequestSeq=3", cdResp)
+		if cdResp.Seq != 0 || cdResp.RequestSeq != 3 {
+			t.Errorf("got %#v, want Seq=0, RequestSeq=3", cdResp)
 		}
 
 		client.ContinueRequest(1)
 		contResp := client.ExpectContinueResponse(t)
-		if contResp.RequestSeq != 4 {
-			t.Errorf("got %#v, want RequestSeq=4", contResp)
+		if contResp.Seq != 0 || contResp.RequestSeq != 4 {
+			t.Errorf("got %#v, want Seq=0, RequestSeq=4", contResp)
 		}
 		client.ExpectTerminatedEvent(t)
 
 		client.DisconnectRequest()
 		dResp := client.ExpectDisconnectResponse(t)
-		if dResp.RequestSeq != 5 {
-			t.Errorf("got %#v, want RequestSeq=5", dResp)
+		if dResp.Seq != 0 || dResp.RequestSeq != 5 {
+			t.Errorf("got %#v, want Seq=0, RequestSeq=5", dResp)
 		}
 	})
 }

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -55,45 +55,47 @@ func TestStopOnEntry(t *testing.T) {
 	runTest(t, "increment", func(client *daptest.Client, fixture protest.Fixture) {
 		client.InitializeRequest()
 		initResp := client.ExpectInitializeResponse(t)
-		if initResp.RequestSeq != 0 || !initResp.Success || !initResp.Body.SupportsConfigurationDoneRequest {
-			t.Errorf("got %#v, want RequestSeq=0, Success=true, SupportsConfigurationDoneRequest=true", initResp)
+		if initResp.RequestSeq != 0 {
+			t.Errorf("got %#v, want RequestSeq=0", initResp)
 		}
 
 		client.LaunchRequest(fixture.Path, true /*stopOnEntry*/)
 		client.ExpectInitializedEvent(t)
 		launchResp := client.ExpectLaunchResponse(t)
-		if launchResp.RequestSeq != 1 || !launchResp.Success {
-			t.Errorf("got %#v, want RequestSeq=1, Success=true", launchResp)
+		if launchResp.RequestSeq != 1 {
+			t.Errorf("got %#v, want RequestSeq=1", launchResp)
 		}
 
 		client.SetExceptionBreakpointsRequest()
 		sResp := client.ExpectSetExceptionBreakpointsResponse(t)
-		if sResp.RequestSeq != 2 || !sResp.Success {
-			t.Errorf("got %#v, want RequestSeq=2, Success=true", sResp)
+		if sResp.RequestSeq != 2 {
+			t.Errorf("got %#v, want RequestSeq=2", sResp)
 		}
 
 		client.ConfigurationDoneRequest()
 		stopEvent := client.ExpectStoppedEvent(t)
-		if stopEvent.Body.Reason != "breakpoint" || stopEvent.Body.ThreadId != 1 || !stopEvent.Body.AllThreadsStopped {
+		if stopEvent.Body.Reason != "breakpoint" ||
+			stopEvent.Body.ThreadId != 1 ||
+			!stopEvent.Body.AllThreadsStopped {
 			t.Errorf("got %#v, want Body Reason=\"breakpoint\", ThreadId=1, AllThreadsStopped=true", stopEvent)
 		}
 
 		cdResp := client.ExpectConfigurationDoneResponse(t)
-		if cdResp.RequestSeq != 3 || !cdResp.Success {
-			t.Errorf("got %#v, want RequestSeq=3, Success=true", cdResp)
+		if cdResp.RequestSeq != 3 {
+			t.Errorf("got %#v, want RequestSeq=3", cdResp)
 		}
 
 		client.ContinueRequest(1)
 		contResp := client.ExpectContinueResponse(t)
-		if contResp.RequestSeq != 4 || !contResp.Success {
-			t.Errorf("got %#v, want RequestSeq=4, Success=true", contResp)
+		if contResp.RequestSeq != 4 {
+			t.Errorf("got %#v, want RequestSeq=4", contResp)
 		}
 		client.ExpectTerminatedEvent(t)
 
 		client.DisconnectRequest()
 		dResp := client.ExpectDisconnectResponse(t)
-		if dResp.RequestSeq != 5 || !dResp.Success {
-			t.Errorf("got %#v, want RequestSeq=5, Success=true", dResp)
+		if dResp.RequestSeq != 5 {
+			t.Errorf("got %#v, want RequestSeq=5", dResp)
 		}
 	})
 }
@@ -106,8 +108,8 @@ func TestSetBreakpoint(t *testing.T) {
 		client.LaunchRequest(fixture.Path, false /*stopOnEntry*/)
 		client.ExpectInitializedEvent(t)
 		launchResp := client.ExpectLaunchResponse(t)
-		if launchResp.RequestSeq != 1 || !launchResp.Success {
-			t.Errorf("got %#v, want RequestSeq=1, Success=true", launchResp)
+		if launchResp.RequestSeq != 1 {
+			t.Errorf("got %#v, want RequestSeq=1", launchResp)
 		}
 
 		client.SetBreakpointsRequest(fixture.Source, []int{8, 100})
@@ -117,7 +119,7 @@ func TestSetBreakpoint(t *testing.T) {
 		}
 		bkpt0 := sResp.Body.Breakpoints[0]
 		if !bkpt0.Verified || bkpt0.Line != 8 {
-			t.Errorf("got breakpoint 0 = %#v, want Verified=true, Line=8", bkpt0)
+			t.Errorf("got breakpoints[0] = %#v, want Verified=true, Line=8", bkpt0)
 		}
 
 		client.SetExceptionBreakpointsRequest()
@@ -125,8 +127,8 @@ func TestSetBreakpoint(t *testing.T) {
 
 		client.ConfigurationDoneRequest()
 		cdResp := client.ExpectConfigurationDoneResponse(t)
-		if cdResp.RequestSeq != 4 || !cdResp.Success {
-			t.Errorf("got %#v, want RequestSeq=4, Success=true", cdResp)
+		if cdResp.RequestSeq != 4 {
+			t.Errorf("got %#v, want RequestSeq=4", cdResp)
 		}
 
 		client.ContinueRequest(1)
@@ -182,8 +184,8 @@ func TestBadLaunchRequests(t *testing.T) {
 		// We failed to launch the program. Make sure shutdown still works.
 		client.DisconnectRequest()
 		dresp := client.ExpectDisconnectResponse(t)
-		if dresp.RequestSeq != 3 || !dresp.Success {
-			t.Errorf("got %#v, want RequestSeq=3, Success=true", dresp)
+		if dresp.RequestSeq != 3 {
+			t.Errorf("got %#v, want RequestSeq=3", dresp)
 		}
 	})
 }

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -137,7 +137,7 @@ func TestSetBreakpoint(t *testing.T) {
 		if stopEvent1.Body.Reason != "breakpoint" ||
 			stopEvent1.Body.ThreadId != 1 ||
 			!stopEvent1.Body.AllThreadsStopped {
-			t.Errorf("got %#v, want Body Reason=\"breakpoint\", ThreadId=1, AllThreadsStopped=true", stopEvent1)
+			t.Errorf("got %#v, want Body={Reason=\"breakpoint\", ThreadId=1, AllThreadsStopped=true}", stopEvent1)
 		}
 		client.ExpectContinueResponse(t)
 

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -1,9 +1,7 @@
 package dap
 
 import (
-	"bytes"
 	"flag"
-	"fmt"
 	"net"
 	"os"
 	"testing"
@@ -40,16 +38,6 @@ func startDAPServer(t *testing.T) (server *Server, addr string) {
 	return server, listener.Addr().String()
 }
 
-func expectMessage(t *testing.T, client *daptest.Client, want []byte) {
-	got, err := client.ReadBaseMessage()
-	if err != nil {
-		t.Error(err)
-	}
-	if !bytes.Equal(got, want) {
-		t.Errorf("\ngot  %q\nwant %q", got, want)
-	}
-}
-
 // name is for _fixtures/<name>.go
 func runTest(t *testing.T, name string, test func(c *daptest.Client, f protest.Fixture)) {
 	var buildFlags protest.BuildFlags
@@ -63,98 +51,141 @@ func runTest(t *testing.T, name string, test func(c *daptest.Client, f protest.F
 	test(client, fixture)
 }
 
-// TODO(polina): instead of hardcoding message bytes,
-// add methods to client to receive, decode and verify responses.
-
 func TestStopOnEntry(t *testing.T) {
 	runTest(t, "increment", func(client *daptest.Client, fixture protest.Fixture) {
 		client.InitializeRequest()
-		expectMessage(t, client, []byte(`{"seq":0,"type":"response","request_seq":0,"success":true,"command":"initialize","body":{"supportsConfigurationDoneRequest":true}}`))
+		initResp := client.ExpectInitializeResponse(t)
+		if initResp.RequestSeq != 0 || !initResp.Success || !initResp.Body.SupportsConfigurationDoneRequest {
+			t.Errorf("got %#v, want RequestSeq=0, Success=true, SupportsConfigurationDoneRequest=true", initResp)
+		}
 
 		client.LaunchRequest(fixture.Path, true /*stopOnEntry*/)
-		expectMessage(t, client, []byte(`{"seq":0,"type":"event","event":"initialized"}`))
-		expectMessage(t, client, []byte(`{"seq":0,"type":"response","request_seq":1,"success":true,"command":"launch"}`))
+		client.ExpectInitializedEvent(t)
+		launchResp := client.ExpectLaunchResponse(t)
+		if launchResp.RequestSeq != 1 || !launchResp.Success {
+			t.Errorf("got %#v, want RequestSeq=1, Success=true", launchResp)
+		}
 
 		client.SetExceptionBreakpointsRequest()
-		expectMessage(t, client, []byte(`{"seq":0,"type":"response","request_seq":2,"success":true,"command":"setExceptionBreakpoints"}`))
+		sResp := client.ExpectSetExceptionBreakpointsResponse(t)
+		if sResp.RequestSeq != 2 || !sResp.Success {
+			t.Errorf("got %#v, want RequestSeq=2, Success=true", sResp)
+		}
 
 		client.ConfigurationDoneRequest()
-		expectMessage(t, client, []byte(`{"seq":0,"type":"event","event":"stopped","body":{"reason":"breakpoint","threadId":1,"allThreadsStopped":true}}`))
-		expectMessage(t, client, []byte(`{"seq":0,"type":"response","request_seq":3,"success":true,"command":"configurationDone"}`))
+		stopEvent := client.ExpectStoppedEvent(t)
+		if stopEvent.Body.Reason != "breakpoint" || stopEvent.Body.ThreadId != 1 || !stopEvent.Body.AllThreadsStopped {
+			t.Errorf("got %#v, want Body Reason=\"breakpoint\", ThreadId=1, AllThreadsStopped=true", stopEvent)
+		}
+
+		cdResp := client.ExpectConfigurationDoneResponse(t)
+		if cdResp.RequestSeq != 3 || !cdResp.Success {
+			t.Errorf("got %#v, want RequestSeq=3, Success=true", cdResp)
+		}
 
 		client.ContinueRequest(1)
-		expectMessage(t, client, []byte(`{"seq":0,"type":"response","request_seq":4,"success":true,"command":"continue","body":{}}`))
-		expectMessage(t, client, []byte(`{"seq":0,"type":"event","event":"terminated","body":{}}`))
+		contResp := client.ExpectContinueResponse(t)
+		if contResp.RequestSeq != 4 || !contResp.Success {
+			t.Errorf("got %#v, want RequestSeq=4, Success=true", contResp)
+		}
+		client.ExpectTerminatedEvent(t)
 
 		client.DisconnectRequest()
-		expectMessage(t, client, []byte(`{"seq":0,"type":"response","request_seq":5,"success":true,"command":"disconnect"}`))
+		dResp := client.ExpectDisconnectResponse(t)
+		if dResp.RequestSeq != 5 || !dResp.Success {
+			t.Errorf("got %#v, want RequestSeq=5, Success=true", dResp)
+		}
 	})
 }
 
 func TestSetBreakpoint(t *testing.T) {
 	runTest(t, "increment", func(client *daptest.Client, fixture protest.Fixture) {
 		client.InitializeRequest()
-		expectMessage(t, client, []byte(`{"seq":0,"type":"response","request_seq":0,"success":true,"command":"initialize","body":{"supportsConfigurationDoneRequest":true}}`))
+		client.ExpectInitializeResponse(t)
 
 		client.LaunchRequest(fixture.Path, false /*stopOnEntry*/)
-		expectMessage(t, client, []byte(`{"seq":0,"type":"event","event":"initialized"}`))
-		expectMessage(t, client, []byte(`{"seq":0,"type":"response","request_seq":1,"success":true,"command":"launch"}`))
+		client.ExpectInitializedEvent(t)
+		launchResp := client.ExpectLaunchResponse(t)
+		if launchResp.RequestSeq != 1 || !launchResp.Success {
+			t.Errorf("got %#v, want RequestSeq=1, Success=true", launchResp)
+		}
 
 		client.SetBreakpointsRequest(fixture.Source, []int{8, 100})
-		expectMessage(t, client, []byte(`{"seq":0,"type":"response","request_seq":2,"success":true,"command":"setBreakpoints","body":{"breakpoints":[{"verified":true,"source":{},"line":8}]}}`))
+		sResp := client.ExpectSetBreakpointsResponse(t)
+		if len(sResp.Body.Breakpoints) != 1 {
+			t.Errorf("got %#v, want len(Breakpoints)=1", sResp)
+		}
+		bkpt0 := sResp.Body.Breakpoints[0]
+		if !bkpt0.Verified || bkpt0.Line != 8 {
+			t.Errorf("got breakpoint 0 = %#v, want Verified=true, Line=8", bkpt0)
+		}
 
 		client.SetExceptionBreakpointsRequest()
-		expectMessage(t, client, []byte(`{"seq":0,"type":"response","request_seq":3,"success":true,"command":"setExceptionBreakpoints"}`))
+		client.ExpectSetExceptionBreakpointsResponse(t)
 
 		client.ConfigurationDoneRequest()
-		expectMessage(t, client, []byte(`{"seq":0,"type":"response","request_seq":4,"success":true,"command":"configurationDone"}`))
+		cdResp := client.ExpectConfigurationDoneResponse(t)
+		if cdResp.RequestSeq != 4 || !cdResp.Success {
+			t.Errorf("got %#v, want RequestSeq=4, Success=true", cdResp)
+		}
 
 		client.ContinueRequest(1)
-		expectMessage(t, client, []byte(`{"seq":0,"type":"event","event":"stopped","body":{"reason":"breakpoint","threadId":1,"allThreadsStopped":true}}`))
-		expectMessage(t, client, []byte(`{"seq":0,"type":"response","request_seq":5,"success":true,"command":"continue","body":{}}`))
+		stopEvent1 := client.ExpectStoppedEvent(t)
+		if stopEvent1.Body.Reason != "breakpoint" || stopEvent1.Body.ThreadId != 1 || !stopEvent1.Body.AllThreadsStopped {
+			t.Errorf("got %#v, want Body Reason=\"breakpoint\", ThreadId=1, AllThreadsStopped=true", stopEvent1)
+		}
+		client.ExpectContinueResponse(t)
 
 		client.ContinueRequest(1)
-		expectMessage(t, client, []byte(`{"seq":0,"type":"event","event":"terminated","body":{}}`))
-		expectMessage(t, client, []byte(`{"seq":0,"type":"response","request_seq":6,"success":true,"command":"continue","body":{}}`))
+		client.ExpectTerminatedEvent(t)
+		client.ExpectContinueResponse(t)
 
 		client.DisconnectRequest()
-		expectMessage(t, client, []byte(`{"seq":0,"type":"response","request_seq":7,"success":true,"command":"disconnect"}`))
+		client.ExpectDisconnectResponse(t)
 	})
-}
-
-func expectErrorResponse(t *testing.T, client *daptest.Client, requestSeq int, command string, message string, id int) *dap.ErrorResponse {
-	response, err := client.ReadErrorResponse()
-	if err != nil {
-		t.Error(err)
-		return nil
-	}
-	got := response.(*dap.ErrorResponse)
-	if got.RequestSeq != requestSeq || got.Command != command || got.Message != message || got.Body.Error.Id != id {
-		want := fmt.Sprintf("{RequestSeq: %d, Command: %q, Message: %q, Id: %d}", requestSeq, command, message, id)
-		t.Errorf("\ngot  %#v\nwant %s", got, want)
-		return nil
-	}
-	return got
 }
 
 func TestBadLaunchRequests(t *testing.T) {
 	runTest(t, "increment", func(client *daptest.Client, fixture protest.Fixture) {
 		client.LaunchRequest("", true)
+
+		expectFailedToLaunch := func(response *dap.ErrorResponse, seq int) {
+			if response.RequestSeq != seq {
+				t.Errorf("RequestSeq got %d, want %d", seq, response.RequestSeq)
+			}
+			if response.Command != "launch" {
+				t.Errorf("Command got %q, want \"launch\"", response.Command)
+			}
+			if response.Message != "Failed to launch" {
+				t.Errorf("Message got %q, want \"Failed to launch\"", response.Message)
+			}
+			if response.Body.Error.Id != 3000 {
+				t.Errorf("Id got %d, want 3000", response.Body.Error.Id)
+			}
+		}
+
+		resp := client.ExpectErrorResponse(t)
+		expectFailedToLaunch(resp, 0)
 		// Test for the DAP-specific detailed error message.
-		want := "Failed to launch: The program attribute is missing in debug configuration."
-		if got := expectErrorResponse(t, client, 0, "launch", "Failed to launch", 3000); got != nil && got.Body.Error.Format != want {
-			t.Errorf("got %q, want %q", got.Body.Error.Format, want)
+		wantErrorFormat := "Failed to launch: The program attribute is missing in debug configuration."
+		if resp.Body.Error.Format != wantErrorFormat {
+			t.Errorf("got %q, want %q", resp.Body.Error.Format, wantErrorFormat)
 		}
 
 		// Skip detailed message checks for potentially different OS-specific errors.
 		client.LaunchRequest(fixture.Path+"_does_not_exist", false)
-		expectErrorResponse(t, client, 1, "launch", "Failed to launch", 3000)
+		resp = client.ExpectErrorResponse(t)
+		expectFailedToLaunch(resp, 1)
 
 		client.LaunchRequest(fixture.Source, true) // Not an executable
-		expectErrorResponse(t, client, 2, "launch", "Failed to launch", 3000)
+		resp = client.ExpectErrorResponse(t)
+		expectFailedToLaunch(resp, 2)
 
 		// We failed to launch the program. Make sure shutdown still works.
 		client.DisconnectRequest()
-		expectMessage(t, client, []byte(`{"seq":0,"type":"response","request_seq":3,"success":true,"command":"disconnect"}`))
+		dresp := client.ExpectDisconnectResponse(t)
+		if dresp.RequestSeq != 3 || !dresp.Success {
+			t.Errorf("got %#v, want RequestSeq=3, Success=true", dresp)
+		}
 	})
 }

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -55,30 +55,30 @@ func TestStopOnEntry(t *testing.T) {
 	runTest(t, "increment", func(client *daptest.Client, fixture protest.Fixture) {
 		client.InitializeRequest()
 		initResp := client.ExpectInitializeResponse(t)
-		if initResp.RequestSeq != 0 {
-			t.Errorf("got %#v, want RequestSeq=0", initResp)
+		if initResp.Seq != 0 || initResp.RequestSeq != 0 {
+			t.Errorf("got %#v, want Seq=0, RequestSeq=0", initResp)
 		}
 
 		client.LaunchRequest(fixture.Path, true /*stopOnEntry*/)
 		client.ExpectInitializedEvent(t)
 		launchResp := client.ExpectLaunchResponse(t)
-		if launchResp.RequestSeq != 1 {
-			t.Errorf("got %#v, want RequestSeq=1", launchResp)
+		if launchResp.Seq != 0 || launchResp.RequestSeq != 1 {
+			t.Errorf("got %#v, want Seq=0, RequestSeq=1", launchResp)
 		}
 
 		client.SetExceptionBreakpointsRequest()
 		sResp := client.ExpectSetExceptionBreakpointsResponse(t)
-		if sResp.RequestSeq != 2 {
-			t.Errorf("got %#v, want RequestSeq=2", sResp)
+		if sResp.Seq != 0 || sResp.RequestSeq != 2 {
+			t.Errorf("got %#v, want Seq=0, RequestSeq=2", sResp)
 		}
 
 		client.ConfigurationDoneRequest()
 		stopEvent := client.ExpectStoppedEvent(t)
-		if stopEvent.Body.Reason != "breakpoint" ||
-			stopEvent.Seq != 0 ||
+		if stopEvent.Seq != 0 ||
+			stopEvent.Body.Reason != "breakpoint" ||
 			stopEvent.Body.ThreadId != 1 ||
 			!stopEvent.Body.AllThreadsStopped {
-			t.Errorf("got %#v, want Body Reason=\"breakpoint\", Seq=0, ThreadId=1, AllThreadsStopped=true", stopEvent)
+			t.Errorf("got %#v, want Seq=0, Body={Reason=\"breakpoint\", ThreadId=1, AllThreadsStopped=true}", stopEvent)
 		}
 
 		cdResp := client.ExpectConfigurationDoneResponse(t)
@@ -134,7 +134,9 @@ func TestSetBreakpoint(t *testing.T) {
 
 		client.ContinueRequest(1)
 		stopEvent1 := client.ExpectStoppedEvent(t)
-		if stopEvent1.Body.Reason != "breakpoint" || stopEvent1.Body.ThreadId != 1 || !stopEvent1.Body.AllThreadsStopped {
+		if stopEvent1.Body.Reason != "breakpoint" ||
+			stopEvent1.Body.ThreadId != 1 ||
+			!stopEvent1.Body.AllThreadsStopped {
 			t.Errorf("got %#v, want Body Reason=\"breakpoint\", ThreadId=1, AllThreadsStopped=true", stopEvent1)
 		}
 		client.ExpectContinueResponse(t)

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -174,12 +174,10 @@ func TestBadLaunchRequests(t *testing.T) {
 
 		// Skip detailed message checks for potentially different OS-specific errors.
 		client.LaunchRequest(fixture.Path+"_does_not_exist", false)
-		resp = client.ExpectErrorResponse(t)
-		expectFailedToLaunch(resp, 1)
+		expectFailedToLaunch(client.ExpectErrorResponse(t), 1)
 
 		client.LaunchRequest(fixture.Source, true) // Not an executable
-		resp = client.ExpectErrorResponse(t)
-		expectFailedToLaunch(resp, 2)
+		expectFailedToLaunch(client.ExpectErrorResponse(t), 2)
 
 		// We failed to launch the program. Make sure shutdown still works.
 		client.DisconnectRequest()

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -961,6 +961,11 @@ func TestDisasm(t *testing.T) {
 
 		pcstart := d1[0].Loc.PC
 		pcend := d1[len(d1)-1].Loc.PC + uint64(len(d1[len(d1)-1].Bytes))
+
+		// start address should be less than end address
+		_, err = c.DisassembleRange(api.EvalScope{-1, 0, 0}, pcend, pcstart, api.IntelFlavour)
+		assertError(err, t, "DisassembleRange()")
+
 		d2, err := c.DisassembleRange(api.EvalScope{-1, 0, 0}, pcstart, pcend, api.IntelFlavour)
 		assertNoError(err, t, "DisassembleRange()")
 

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -1178,6 +1178,9 @@ func TestCallFunction(t *testing.T) {
 
 		{"ga.PRcvr(2)", []string{`:string:"2 - 0 = 2"`}, nil},
 
+		{"x.CallMe()", nil, nil},
+		{"x2.CallMe(5)", []string{":int:25"}, nil},
+
 		// Nested function calls tests
 
 		{`onetwothree(intcallpanic(2))`, []string{`:[]int:[]int len: 3, cap: 3, [3,4,5]`}, nil},


### PR DESCRIPTION
server_test is currently using byte-wise comparison of serialized JSON strings for checking expected messages.

This has several issues:

* The encoding is brittle and not well defined - the json module doesn't guarantee the order in which it serializes struct fields.
* It's an abstraction leak: clients of go-dap shouldn't be relying on its internal serialization details, only on the structs defined in schematypes which is the exported API.
* Tests are difficult to read because the reader has to implicitly map between exported types and details of the DAP protocol - e.g. mentally translate `"type":"response", "command":"initialize"` to `InitializeResponse`. This is obscured by the fact that these fields are sometimes not next to each other. In the future when larger messages will be exchanged (i.e. a `BreakpointsResponse` with 10 breakpoints, the `[]byte` strings will be so long as to render their interpretation impossible by eye). We already ran into this issue with error responses which were too strict on a byte-by-byte comparison that had to be relaxed.

The new approach is also not perfect. The largest issue is the `Expect...` methods on `Client` which have to be added per message. But the tests themselves are not too verbose, and in many cases can be shortened by writing helper functions, or just not repeating themselves too much (e.g. we don't have to keep track of sequence numbers in responses in *every* test).

Longer term this will be solved by writing most tests in a higher-level framework similar to the one the current Delve service uses.